### PR TITLE
refactor: default to use `textEdit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ functions that takes dozens of arguments_.
 
 ## Installation 
 
-This plugin is developed and tested on the latest stable release of neovim.
+> This plugin is developed and tested on the latest stable release of neovim.
 
 Use your favourite plugin manager.
 ```lua
@@ -24,12 +24,10 @@ Use your favourite plugin manager.
         {
             "<Leader>I", -- Use whatever keymap you want.
             function()
-                -- make sure to `return` the `fill` call.
-                return require("inlayhint-filler").fill()
+                require("inlayhint-filler").fill()
             end,
             desc = "Insert the inlay-hint under cursor into the buffer.",
             mode = { "n", "v" }, -- include 'v' if you want to use it in visual selection mode
-            expr = true -- necessary
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ This plugin provides an API to insert the inlay-hint under the cursor into the
 buffer.
 In Python, this is useful when you want to insert the type annotation from the
 language server into the code, or you want to turn an unnamed argument (`f(10)`)
-into a named argument (`f(x=10)`) (_particularly useful when working with
-functions that takes dozens of arguments_).
+into a named argument (`f(x=10)`). _This is particularly useful when working with
+functions that takes dozens of arguments_.
 
 ## Installation 
 
@@ -24,14 +24,20 @@ Use your favourite plugin manager.
         {
             "<Leader>I", -- Use whatever keymap you want.
             function()
-                require("inlayhint-filler").fill()
+                -- make sure to `return` the `fill` call.
+                return require("inlayhint-filler").fill()
             end,
             desc = "Insert the inlay-hint under cursor into the buffer.",
-            mode = { "n", "v" } -- include 'v' if you want to use it in visual selection mode
+            mode = { "n", "v" }, -- include 'v' if you want to use it in visual selection mode
+            expr = true -- necessary
         }
     }
 }
 ```
+
+The normal mode filling is dot-repeatable: when you trigger the
+keymap in normal mode, you can move your cursor to the next inlay hint and
+press `.`, and the hint will be inserted.
 
 ## Configuration
 > [!NOTE]
@@ -46,18 +52,14 @@ The table you pass to the `fill` function will not affect the global options.
 
 ```lua 
 require('inlayhint-filler').setup({ 
-    bufnr = 0, -- integer?
-    client_id = nil, -- integer?
     blacklisted_servers = {} -- string[]
 })
 
 ```
 
-- `bufnr`: specify the buffer number (`0` for the current one);
-- `client_id`: specify the source of the inlay hint;
 - `blacklisted_servers`: the names of language servers from which the inlay hints should
-  be ignored. The names are valid as long as they work with
-  `vim.lsp.get_clients()`.
+  be ignored.
+
 ## Usage 
 Suppose you have a python code snippet like this:
 
@@ -80,25 +82,16 @@ and convert the virtual text into actual code in the buffer:
 You can also visual-select a code block and the `fill()` function will insert
 all inlay hints inside the selected block.
 
-### Dot-repeat
-
-The `fill` function can be used as a [`operatorfunc`](https://neovim.io/doc/user/options.html#'operatorfunc'), which makes it
-dot-repeatable. You'll just need to make some changes to the keymap:
-
-```lua
-vim.keymap.set({ "n", "v" }, "<Leader>I", function()
-  vim.o.operatorfunc = "v:lua.require'inlayhint-filler'.fill"
-  return "g@ "
-end, { expr = true })
-```
-
-This will be part of the plugin soon, so that you don't have to handle the
-`operatorfunc` yourself.
-
 ### Language server support
 This plugin is supposed to be language-server-agnostic, but if you encounter any
 issues with a specific language/language server, please open an issue (preferably
-following the issue template for bug report).
+following the issue template for bug report). 
+
+This plugin works best if the inlay hints returned by the language servers
+contain [`textEdits`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit)
+(see [`inlayHint` specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint) 
+for details). If it's not found, this plugin will instead use the `label` as the
+inserted text.
 
 ## Todo 
 - [x] implement support for visual selection mode.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ require('inlayhint-filler').setup({
 ```
 
 - `blacklisted_servers`: the names of language servers from which the inlay hints should
-  be ignored.
+  be ignored. You may also disable the relevant capability (`inlayHintProvider`)
+  of the server when you call `vim.lsp.config()` on the server, which disable
+  _all_ inlayHint-related features from the particular server.
 
 ## Usage 
 Suppose you have a python code snippet like this:

--- a/lua/inlayhint-filler.lua
+++ b/lua/inlayhint-filler.lua
@@ -25,7 +25,7 @@ local function get_text_edits(hint)
   )
 
   local label = hint.label
-  if type(label) == "table" then
+  if type(label) == "table" and not vim.tbl_isempty(label) then
     label = label[1].value
   end
   return {

--- a/lua/inlayhint-filler.lua
+++ b/lua/inlayhint-filler.lua
@@ -3,174 +3,81 @@ M = {}
 local api = vim.api
 
 ---@class InlayHintFillerOpts
----@field bufnr integer?
----@field client_id integer?
----@field blacklisted_servers string[]?
+---@field blacklisted_servers string[]
 
 ---@type InlayHintFillerOpts
-local DEFAULT_OPTS = { bufnr = 0, client_id = nil, blacklisted_servers = {} }
+local DEFAULT_OPTS = { blacklisted_servers = {} }
+
 ---@type InlayHintFillerOpts
-local options = vim.tbl_deep_extend("keep", {}, DEFAULT_OPTS)
+local options = vim.deepcopy(DEFAULT_OPTS)
 
-local blacklisted_client_id = {}
+---@param hint lsp.InlayHint
+---@return lsp.TextEdit[]
+local function get_text_edits(hint)
+  if hint.textEdits then
+    return hint.textEdits
+  end
 
----@param hint_item lsp.InlayHint
----@return string
-local function get_inserted_text(hint_item)
-  local hint_text
-  if type(hint_item.label) == "string" then
-    hint_text = hint_item.label
-  else
-    hint_text = hint_item.label[1].value ---@cast hint_text string
+  vim.schedule_wrap(vim.notify)(
+    "Failed to extract text edits from LSP.",
+    vim.log.levels.WARN,
+    { title = "Inlayhint-Filler" }
+  )
+
+  local label = hint.label
+  if type(label) == "table" then
+    label = label[1].value
   end
-  if hint_item.paddingLeft then
-    hint_text = " " .. hint_text
-  end
-  if hint_item.paddingRight then
-    hint_text = hint_text .. " "
-  end
-  return hint_text
+  return {
+    ---@type lsp.TextEdit
+    {
+      range = { start = hint.position, ["end"] = hint.position },
+      newText = string.format(
+        "%s%s%s",
+        hint.paddingLeft and " " or "",
+        label,
+        hint.paddingRight and " " or ""
+      ),
+    },
+  }
 end
 
----@param hints lsp.InlayHint[]
----@param opts InlayHintFillerOpts
-local function process_hints(hints, opts)
-  table.sort(hints, function(item1, item2)
-    local pos1 = item1.position
-    local pos2 = item2.position
-    return pos1.line < pos2.line
-      or (pos1.line == pos2.line and pos1.character < pos2.character)
-  end)
-
-  local current_line = -1
-  local line_content = ""
-  local offsets = {}
-
-  for i = 1, #hints do
-    local hint_item = hints[i]
-    local pos = hint_item.position
-    if pos.line ~= current_line then
-      if current_line >= 0 and #line_content > 0 then
-        offsets[current_line] = offsets[current_line] or 0
-        vim.schedule(function()
-          api.nvim_buf_set_lines(
-            opts.bufnr,
-            current_line,
-            current_line + 1,
-            false,
-            { line_content }
-          )
-        end)
-      end
-      local fresh_lines =
-        api.nvim_buf_get_lines(opts.bufnr, pos.line, pos.line + 1, false)
-      line_content = fresh_lines[1] or ""
-      current_line = pos.line
-      offsets[current_line] = offsets[current_line] or 0
-    end
-
-    local inserted_text = get_inserted_text(hint_item)
-    local insert_pos = pos.character + offsets[current_line]
-    line_content = line_content:sub(1, insert_pos)
-      .. inserted_text
-      .. line_content:sub(insert_pos + 1)
-    offsets[current_line] = offsets[current_line] + #inserted_text
-  end
-
-  if current_line >= 0 and #line_content > 0 then
-    vim.schedule(function()
-      api.nvim_buf_set_lines(
-        opts.bufnr,
-        current_line,
-        current_line + 1,
-        false,
-        { line_content }
-      )
-    end)
-  end
-end
-
-local function refresh_clients()
-  blacklisted_client_id = {}
-  for _, server_name in pairs(options.blacklisted_servers) do
-    local clients = vim.lsp.get_clients({ name = server_name })
-    for _, client in pairs(clients) do
-      vim.list_extend(blacklisted_client_id, { client.id })
-    end
-  end
-end
-
---- Get the InlayHints the hard way.
---- Avoids incompatibility in case another plugin overrides the inlayhint handler.
----@param bufnr integer
+---@param pos lsp.Position
 ---@param range lsp.Range
----@return lsp.InlayHint[]
-local function get_hints(bufnr, range)
-  local hints = {} ---@type lsp.InlayHint[]
-
-  ---@type vim.lsp.Client
-  local clients
-  if DEFAULT_OPTS.client_id ~= nil then
-    clients = vim.lsp.get_clients({ client_id = DEFAULT_OPTS.client_id })
+---@return boolean
+local function is_lsp_position_in_range(pos, range)
+  if pos.line < range.start.line or pos.line > range["end"].line then
+    return false
+  elseif pos.line == range.start.line and pos.character < range.start.character then
+    return false
+  elseif
+    pos.line == range["end"].line
+    and (pos.character >= range["end"].character or pos.character == -1)
+  then
+    -- `end` is exclusive
+    return false
   else
-    clients = vim.lsp.get_clients({ bufnr = bufnr })
+    return true
   end
-
-  for _, client in pairs(clients) do
-    if
-      not vim.list_contains(blacklisted_client_id, client.id)
-      and client.server_capabilities.inlayHintProvider
-    then
-      -- not blacklisted
-      local range_params = vim.lsp.util.make_range_params(bufnr, client.offset_encoding)
-      range_params.range = range
-      local ret, _ = client:request_sync(
-        vim.lsp.protocol.Methods.textDocument_inlayHint,
-        range_params,
-        2 ^ 32 - 1,
-        bufnr
-      )
-      if ret ~= nil then
-        local result = ret.result
-        if result == {} or result == nil then
-          goto continue
-        end
-        for _, inlay_hint in pairs(result) do
-          if
-            not vim.list_contains(
-              vim.tbl_map(function(v)
-                return vim.deep_equal(v.position, inlay_hint.position)
-              end, hints),
-              true
-            )
-          then
-            table.insert(hints, inlay_hint)
-          end
-        end
-      end
-    end
-    ::continue::
-  end
-  return hints
 end
 
----@param opts InlayHintFillerOpts?
-M.fill = function(opts)
-  refresh_clients()
+---@param opts? InlayHintFillerOpts
+M._fill = function(opts)
+  local bufnr = vim.api.nvim_get_current_buf()
   ---@type InlayHintFillerOpts
   opts = vim.tbl_deep_extend("keep", {} or opts, options, DEFAULT_OPTS)
   local mode = vim.fn.mode()
+  ---@type lsp.Range?
+  local lsp_range
+
   if mode == "n" then
     local cursor_pos = api.nvim_win_get_cursor(0)
     local row = cursor_pos[1] - 1
     local col = cursor_pos[2]
-    local hints = get_hints(opts.bufnr, {
+    lsp_range = {
       start = { line = row, character = col },
-      ["end"] = { line = row, character = col + 1 },
-    })
-    if hints and #hints > 0 then
-      process_hints(hints, opts)
-    end
+      ["end"] = { line = row, character = col + 2 },
+    }
   elseif string.lower(mode):find("^.?v%a?") then
     local start_pos = vim.fn.getpos("v")
     local end_pos = vim.fn.getpos(".")
@@ -181,8 +88,7 @@ M.fill = function(opts)
       start_pos, end_pos = end_pos, start_pos
     end
 
-    ---@type lsp.Range
-    local lsp_range = {
+    lsp_range = {
       start = { line = start_pos[2] - 1, character = start_pos[3] - 1 },
       ["end"] = { line = end_pos[2] - 1, character = end_pos[3] - 1 },
     }
@@ -191,22 +97,71 @@ M.fill = function(opts)
       lsp_range["end"].line = lsp_range["end"].line + 1
       lsp_range["end"].character = 0
     end
-    local hints = get_hints(opts.bufnr, lsp_range)
-    if hints and #hints > 0 then
-      process_hints(hints, opts)
+  end
+
+  if lsp_range == nil then
+    return
+  end
+
+  local done = false
+  for cli in
+    vim.iter(vim.lsp.get_clients({
+      bufnr = bufnr,
+      method = vim.lsp.protocol.Methods.textDocument_inlayHint,
+    }))
+  do
+    if done then
+      return
+    end
+    if not vim.list_contains(opts.blacklisted_servers, cli.name) then
+      local params = vim.lsp.util.make_range_params(0, cli.offset_encoding)
+      params.range = lsp_range
+      cli:request(
+        vim.lsp.protocol.Methods.textDocument_inlayHint,
+        params,
+        function(_, result, context, _)
+          if done then
+            return
+          end
+          ---@type lsp.InlayHint[]
+          result = vim
+            .iter(result or {})
+            :filter(
+              ---@param hint lsp.InlayHint
+              function(hint)
+                return is_lsp_position_in_range(hint.position, lsp_range)
+              end
+            )
+            :totable()
+          if result == nil or vim.tbl_isempty(result) then
+            return
+          end
+
+          done = true
+          vim.schedule_wrap(vim.lsp.util.apply_text_edits)(
+            vim.iter(result):map(get_text_edits):flatten(1):totable(),
+            context.bufnr,
+            cli.offset_encoding
+          )
+        end
+      )
     end
   end
-  api.nvim_input("<esc>")
+end
+
+---@param opts InlayHintFillerOpts?
+M.fill = function(opts)
+  vim.o.operatorfunc = "v:lua.require'inlayhint-filler'._fill"
+  if vim.fn.mode() == "n" then
+    -- normal mode
+    return "g@ "
+  end
+  return M._fill(opts)
 end
 
 ---@param opts InlayHintFillerOpts
 M.setup = function(opts)
   options = vim.tbl_deep_extend("keep", opts or {}, DEFAULT_OPTS)
-  refresh_clients()
-  api.nvim_create_autocmd("LspAttach", {
-    desc = "Refresh in case of LspRestart.",
-    callback = refresh_clients,
-  })
 end
 
 return M


### PR DESCRIPTION
- use `vim.lsp.util.apply_text_edit` to insert the hints;
- default to use `textEdits` as the inserted text. When paired with basedpyright, this'll handle the import where necessary;
- use async LSP operations;
- built-in dot-repeat in normal mode;
- removed excessive options.