### PR TITLE
fix: global `M`

### DIFF
--- a/lua/inlayhint-filler.lua
+++ b/lua/inlayhint-filler.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 local notify = vim.schedule_wrap(vim.notify)
 local api = vim.api


### PR DESCRIPTION
This caused issues with other plugins that also incorrectly used a global `M`, essentially breaking them.